### PR TITLE
fix #1 environments must be prepared and initialized during PREPARE phase when using Lifecycle.PER_CLASS

### DIFF
--- a/junit-env-extension/pom.xml
+++ b/junit-env-extension/pom.xml
@@ -12,7 +12,7 @@
   </parent>
 
   <artifactId>junit-env-extension</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <packaging>jar</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>

--- a/junit-env-extension/src/main/java/eu/coldrye/junit/env/EnvExtension.java
+++ b/junit-env-extension/src/main/java/eu/coldrye/junit/env/EnvExtension.java
@@ -72,6 +72,15 @@ public final class EnvExtension implements TestInstancePostProcessor, ParameterR
   @Override
   public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
 
+    /*
+     * #1 - when using {@code @TestInstance(Lifecycle.PER_CLASS)}, then junit will first
+     *      invoke the {@code AfterAllCallback}S.
+     *      make sure that the environment providers have been prepared
+     */
+    if (!providerManager.isPrepared(context)) {
+      providerManager.prepareEnvironmentProviders(context);
+      providerManager.setUpEnvironments(EnvPhase.INIT, context);
+    }
     fieldInjector.inject(testInstance, context, providerManager.getProviders(context, EnvPhase.PREPARE));
   }
 

--- a/junit-env-extension/src/test/java/eu/coldrye/junit/env/Fixtures.java
+++ b/junit-env-extension/src/test/java/eu/coldrye/junit/env/Fixtures.java
@@ -24,7 +24,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedElement;
-import java.util.Optional;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
 
 public interface Fixtures {
 
@@ -217,5 +218,30 @@ public interface Fixtures {
   @Environment(EnvProvider.class)
   class FifthTestCase {
 
+  }
+
+  class SimpleEnvProvider extends AbstractEnvProvider {
+
+    @Override
+    public boolean canProvideInstance(AnnotatedElement annotated, Class<?> classOrInterface) {
+
+      return annotated.isAnnotationPresent(EnvProvided.class);
+    }
+
+    @Override
+    public Object getOrCreateInstance(AnnotatedElement annotated, Class<?> classOrInterface) {
+
+      return new Object();
+    }
+
+    @Override
+    public void setUpEnvironment(EnvPhase phase, AnnotatedElement annotated) throws Exception {
+
+    }
+
+    @Override
+    public void tearDownEnvironment(EnvPhase phase, AnnotatedElement annotated) throws Exception {
+
+    }
   }
 }

--- a/junit-env-extension/src/test/java/eu/coldrye/junit/env/regression/Issue1Test.java
+++ b/junit-env-extension/src/test/java/eu/coldrye/junit/env/regression/Issue1Test.java
@@ -1,9 +1,14 @@
 package eu.coldrye.junit.env.regression;
 
+import eu.coldrye.junit.env.EnvExtension;
+import eu.coldrye.junit.env.EnvProvided;
+import eu.coldrye.junit.env.Environment;
+import eu.coldrye.junit.env.Fixtures.SimpleEnvProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * #1 - Illegal state exception when using @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -11,11 +16,16 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
  * just a dummy test here, the actual test is that the test class can be instantiated
  * and the after all callback implemented by EnvExtension does not fail
  */
+@ExtendWith(EnvExtension.class)
+@Environment(SimpleEnvProvider.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class Issue1Test {
 
+  @EnvProvided
+  private Object envProvided;
+
   @Test
-  public void afterAllCallbackMustNotFail() {
-    Assertions.assertTrue(true);
+  public void envProvidedMustExist() {
+    Assertions.assertNotNull(envProvided);
   }
 }

--- a/junit-env-hadoop-mini-clusters/junit-env-hadoop-mini-clusters.iml
+++ b/junit-env-hadoop-mini-clusters/junit-env-hadoop-mini-clusters.iml
@@ -7,12 +7,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/examples/hdfs/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/target/generated-sources/delombok" isTestSource="false" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="junit-common" />
-    <orderEntry type="module" module-name="junit-env-extension" />
+    <orderEntry type="library" name="Maven: eu.coldrye.junit:junit-env-extension:1.0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: org.projectlombok:lombok:1.16.18" level="project" />
     <orderEntry type="library" name="Maven: com.github.sakserv:hadoop-mini-clusters-hdfs:0.1.14" level="project" />
     <orderEntry type="library" name="Maven: org.apache.hadoop:hadoop-client:2.7.3.2.6.2.0-205" level="project" />


### PR DESCRIPTION
pom prepare junit-env-extension 1.0.2 bugfix release
